### PR TITLE
set flatten option to false to generate same source layout structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ grunt.initConfig({
 ```
 
 In this example, options are set to separateFiles with a prefix.  Please note, a destination folder is still expected, but a filename should not be included.
+you can now generate separateFiles in same source's folder layout 
 
 ```js
 grunt.initConfig({
   purifycss: {
     options: {
       separateFiles: true,
-      prefix: 'purifiedcss-'
+      prefix: 'purifiedcss-',
+      flatten: flase
     },
     target: {
       src: ['test/fixtures/*.html', 'test/fixtures/*.js'],

--- a/tasks/purifycss.js
+++ b/tasks/purifycss.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
         separateFiles: false,
-        prefix: 'pure-'
+        prefix: 'pure-',
+        flatten:false
     });
 
     var createOutput = function(srcFiles, css, dest) {
@@ -33,7 +34,11 @@ module.exports = function(grunt) {
       if (ext) {
           destFile = dest;
       } else {
-          destFile = dest + '/' + options.prefix + path.basename(css); 
+          if (options.flatten) {
+            destFile = dest + '/' + options.prefix + path.basename(css);   
+          } else {
+            destFile = dest + '/' + path.dirname(css) + '/' + options.prefix + path.basename(css);
+          }
       }
 
       grunt.file.write(path.normalize(destFile), pure);


### PR DESCRIPTION
separated files now can be generated with same layout of it's source folder using 
by setting flatten option to false or true if you still prefer flatten style
